### PR TITLE
chore: add pre-commit hooks with ruff (lint + format)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,14 @@
+# Pre-commit hooks: run ruff (lint + format) before each commit.
+# The ruff version here is pinned to match the `ruff` dev dependency in
+# pyproject.toml and the CI, so local hooks and CI behave identically.
+# When upgrading ruff, bump BOTH this `rev` and the pyproject pin together.
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.16.1
+    hooks:
+      # Linter. --fix auto-fixes what it can; if it changes files the commit is
+      # blocked until you re-stage them, and unfixable issues block outright.
+      - id: ruff-check
+        args: [--fix]
+      # Formatter (reads [tool.ruff] from pyproject.toml, shared config).
+      - id: ruff-format

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,10 +30,16 @@ Model weights are never committed: each node downloads/caches its own weights lo
 
 ## Commands
 
-- Install/sync the whole workspace: `uv sync`
+- Install/sync the whole workspace: `uv sync` (or `uv sync --all-packages`)
 - Sanity-check the workspace wiring: `uv run python -c "import orchestrator, backends.gpu_node"`
+- Lint: `uv run ruff check .`
+- Format (in place): `uv run ruff format .` — verify only: `uv run ruff format --check .`
+- Tests: `uv run pytest packages/ -v`
 
-No lint or test tooling is configured yet in this repo — don't assume a `ruff`/`pytest` setup exists until it's added, and update this section once it is.
+Lint/format is enforced by `ruff` and runs in CI (`.github/workflows/ci.yml`) and
+via pre-commit (`.pre-commit-config.yaml`); the ruff version is pinned to the same
+value in both plus the `pyproject.toml` dev group. See `CONTRIBUTING.md` for local
+pre-commit setup. Ruff config lives in `[tool.ruff]` in `pyproject.toml`.
 
 ## Adding a new workspace package
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,53 @@
+# Contributing to meshcortex
+
+> Minimal guide covering local code-style tooling. It will be expanded with the
+> full contribution workflow (branching, PRs, reviews) later.
+
+## Prerequisites
+
+- [`uv`](https://docs.astral.sh/uv/) installed.
+- Sync the workspace once: `uv sync --all-packages`
+
+## Code style: ruff + pre-commit
+
+Style and linting are enforced by [ruff](https://docs.astral.sh/ruff/), wired
+into [pre-commit](https://pre-commit.com/) so violations are caught **before** a
+commit is created. The same ruff version and configuration run locally and in CI.
+
+### One-time setup
+
+```bash
+uv tool install pre-commit
+pre-commit install
+```
+
+`pre-commit install` registers a git hook, so `ruff` (lint) and `ruff-format`
+run automatically on the files you stage every time you `git commit`.
+
+### How it works
+
+- On `git commit`, the hooks lint and format the staged files.
+- If ruff auto-fixes something (or a file isn't formatted), the commit is
+  **blocked** and the changes are left in your working tree — review, re-stage
+  (`git add`), and commit again.
+- Unfixable lint errors block the commit until you resolve them.
+
+### Useful commands
+
+```bash
+pre-commit run --all-files   # run the hooks over the whole repo
+uv run ruff check .          # lint only (same as CI)
+uv run ruff format .         # format in place
+uv run ruff format --check . # verify formatting without changing files (CI does this)
+```
+
+### Version alignment
+
+The ruff version is pinned in **two** places that must stay in sync:
+
+- `.pre-commit-config.yaml` → `rev: v0.16.1`
+- `pyproject.toml` → `[dependency-groups] dev` → `ruff==0.16.1`
+
+When upgrading ruff, bump **both** together so local hooks and CI keep using an
+identical version. Ruff reads its configuration from `[tool.ruff]` in
+`pyproject.toml`, so lint/format rules are defined once and shared.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,8 @@ members = ["packages/orchestrator", "packages/backends/gpu-node"]
 # Development/CI tooling (not shipped with the packages).
 [dependency-groups]
 dev = [
-    "ruff>=0.8.0",
+    # Pinned to match .pre-commit-config.yaml and CI (identical ruff everywhere).
+    "ruff==0.16.1",
     "pytest>=8.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -56,7 +56,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "pytest", specifier = ">=8.0" },
-    { name = "ruff", specifier = ">=0.8.0" },
+    { name = "ruff", specifier = "==0.16.1" },
 ]
 
 [[package]]


### PR DESCRIPTION
## P0-03 — Pre-commit hooks + shared lint/format config

Adds a local pre-commit layer that mirrors the CI lint/format checks, so style
violations are caught before a commit is created. ruff is pinned to the same
version in pre-commit, the dev dependency, and CI, so local and CI behave
identically.

Closes #5

## What's included
- `.pre-commit-config.yaml` — `astral-sh/ruff-pre-commit` v0.16.1 with the
  `ruff-check` (`--fix`) and `ruff-format` hooks; they read `[tool.ruff]` from
  `pyproject.toml`, so lint/format rules are defined once and shared.
- `pyproject.toml` — pin `ruff==0.16.1` in the dev group so pre-commit and CI
  use an identical version.
- `uv.lock` — refreshed for the pin.
- `CONTRIBUTING.md` — minimal guide: prerequisites, one-time pre-commit setup,
  how the hooks work, useful commands, and the version-alignment note.
- `CLAUDE.md` — updated "Commands" section to document ruff/pytest/pre-commit.

## Acceptance criteria
- [x] `pre-commit run --all-files` passes across the repo
- [x] Commits with lint violations are blocked locally
- [x] CI (P0-02) and pre-commit use an identical ruff version/config (0.16.1)

## Verification
- `pre-commit run --all-files` → `ruff check` and `ruff format` both Passed.
- Staged an intentional violation (`F821`, undefined name) and ran `git commit`
  → blocked (exit 1), no commit created. Reverted.
- Confirmed ruff `0.16.1` in the pre-commit `rev`, the `pyproject.toml` pin, and
  the venv.
- CI parity locally: `ruff check .`, `ruff format --check .`, `pytest packages/ -v`
  all green.

## Notes
- Each developer runs the one-time setup (`uv tool install pre-commit` →
  `pre-commit install`); documented in `CONTRIBUTING.md`.
- Issue steps 1–2 (ruff config + dev dependency) already landed in #4; this PR
  adds the pre-commit wiring, the version pin, and docs.
- ruff is pinned with `==` (not `>=`) because its lint/format output changes
  between versions; bump the pre-commit `rev` and the pyproject pin together.