### PR TITLE
chore: add CODEOWNERS for the project members

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Johansmm @Miguel-Baquero @korokuem @kevinibarralancheros-del

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,6 +41,14 @@ via pre-commit (`.pre-commit-config.yaml`); the ruff version is pinned to the sa
 value in both plus the `pyproject.toml` dev group. See `CONTRIBUTING.md` for local
 pre-commit setup. Ruff config lives in `[tool.ruff]` in `pyproject.toml`.
 
+Before opening a PR, run the same checks CI runs so lint/format failures are
+caught locally instead of after pushing:
+
+```
+uv run ruff check .
+uv run ruff format --check .
+```
+
 ## Adding a new workspace package
 
 A new leaf package needs all of the following, or `uv sync` will not install it:


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` listing all current project members as default owners for the whole repo.
- Documents in `CLAUDE.md` that `ruff check`/`ruff format --check` should be run locally before opening a PR, matching what CI enforces.

## Test plan
- [x] `.github/CODEOWNERS` follows GitHub's required syntax (`pattern owner1 owner2 ...`).
- [x] Docs-only change to `CLAUDE.md`, no code behavior affected.