### PR TITLE
Add gpu-node CLI to download and serve models via llama.cpp or Ollama

### DIFF
--- a/packages/backends/gpu-node/README.md
+++ b/packages/backends/gpu-node/README.md
@@ -1,0 +1,71 @@
+# gpu-node
+
+Thin CLI wrapper that downloads a model from the shared registry (`configs/models.yaml`) and
+serves it behind the OpenAI-compatible contract, via an inference engine that already speaks
+that API. Two engines are supported: llama.cpp (`llama-server`) and Ollama. vLLM is out of
+scope for this package — see `configs/README.md` for the manual vLLM setup instead.
+
+## Install
+
+From the repo root:
+
+```bash
+uv sync
+```
+
+## Usage
+
+```bash
+# Download a registry model's weights only, if not already cached.
+uv run gpu-node download <model-name>
+
+# Download (if needed) and serve a registry model with a given engine.
+uv run gpu-node serve llama-cpp <model-name> [flags]
+uv run gpu-node serve ollama <model-name> [flags]
+```
+
+Both commands are expected to run from the repo root: `--registry` defaults to
+`configs/models.yaml`, resolved relative to the current working directory.
+
+Each engine owns its own flags. See `uv run gpu-node download --help` and
+`uv run gpu-node serve <engine> --help` for reference and defaults.
+
+### Prerequisites
+
+- **llama-cpp**: a `llama-server` binary on `PATH`. See
+  [`configs/README.md`](../../../configs/README.md#llamacpp) for how to get one.
+- **ollama**: an installed and running Ollama service. See
+  [`configs/README.md`](../../../configs/README.md#ollama) for setup.
+
+### Download configuration
+
+`download` (and `serve`'s internal download step) call huggingface_hub directly and let it
+decide where weights land — its own default cache (normally outside the repo, e.g.
+`~/.cache/huggingface/hub`). There are no `gpu-node` flags for auth, cache location, or mirrors;
+set the standard Hugging Face environment variables instead, and huggingface_hub picks
+them up automatically:
+
+| Variable                    | Purpose                                               |
+|-----------------------------|-------------------------------------------------------|
+| `HF_TOKEN`                  | Auth for gated repos, instead of `hf auth login`.     |
+| `HF_HOME` / `HF_HUB_CACHE`  | Relocate the cache to a different directory.          |
+| `HF_HUB_ENABLE_HF_TRANSFER` | Faster downloads via `hf_transfer`.                   |
+| `HF_ENDPOINT`               | Point at a mirror instead of `huggingface.co`.        |
+
+`download` and `serve` both resolve a model's local path through the exact same call, so
+they always agree on where a given model's weights actually are — whichever `HF_HOME`/
+`HF_HUB_CACHE` is set to at the time.
+
+## Verifying contract compliance
+
+Not automated in CI (no GPU or engine binaries on the CI runner) — verify manually:
+
+1. Start the server: `uv run gpu-node serve llama-cpp <model-name>`.
+2. Send a [request](../../../configs/README.md#running-a-registry-model-locally) to the
+   printed endpoint — see step 4 there for the exact command.
+3. The response should validate against `common.contract.ChatCompletionResponse` — the same
+   shape check `packages/common/tests/test_contract.py` runs against a captured llama.cpp
+   fixture.
+
+> **Pending:** verifying that the response reaches this server *through* the orchestrator,
+> until the `orchestrator` package has an actual router.

--- a/packages/backends/gpu-node/pyproject.toml
+++ b/packages/backends/gpu-node/pyproject.toml
@@ -2,7 +2,16 @@
 name = "gpu-node"
 version = "0.1.0"
 requires-python = ">=3.11"
-dependencies = []
+dependencies = [
+    "common",
+    "huggingface_hub>=0.25",
+]
+
+[project.scripts]
+gpu-node = "backends.gpu_node.cli:run"
+
+[tool.uv.sources]
+common = { workspace = true }
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/backends"]

--- a/packages/backends/gpu-node/src/backends/gpu_node/cli.py
+++ b/packages/backends/gpu-node/src/backends/gpu_node/cli.py
@@ -1,0 +1,103 @@
+import argparse
+import warnings
+from pathlib import Path
+
+from backends.gpu_node.download import ensure_model_downloaded
+from backends.gpu_node.engines import ENGINES
+from common.registry import ModelEntry, load_registry
+
+DEFAULT_REGISTRY_PATH = Path("configs/models.yaml")
+
+# Namespace keys that belong to `serve` itself, not to the selected engine's own flags.
+_SERVE_OWN_ARGS = {"command", "engine", "model_name", "registry"}
+
+
+def _add_common_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("model_name", help="Model 'name' field from the registry.")
+    parser.add_argument(
+        "--registry",
+        type=Path,
+        default=DEFAULT_REGISTRY_PATH,
+        help=f"Path to the model registry YAML (default: {DEFAULT_REGISTRY_PATH}).",
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="gpu-node")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    download_parser = subparsers.add_parser(
+        "download",
+        help="Download a registry model's weights, if not already cached.",
+        description=(
+            "Download a registry model's weights via huggingface_hub, if not already "
+            "cached. Where the weights land is huggingface_hub's own decision -- set "
+            "HF_HOME/HF_HUB_CACHE to relocate it."
+        ),
+    )
+    _add_common_arguments(download_parser)
+
+    serve_parser = subparsers.add_parser(
+        "serve",
+        help="Download (if needed) and serve a registry model with a given engine.",
+        description=(
+            "Download (if needed) and serve a registry model. Pick an engine -- each one "
+            "exposes its own flags (see `gpu-node serve <engine> --help`)."
+        ),
+    )
+    engine_subparsers = serve_parser.add_subparsers(dest="engine", required=True)
+
+    # Each engine owns its own flags -- adding a new engine means adding a module with
+    # `HELP`/`add_arguments`/`serve` and one entry in `ENGINES`.
+    for name, engine_module in ENGINES.items():
+        engine_parser = engine_subparsers.add_parser(
+            name, help=engine_module.HELP, description=engine_module.HELP
+        )
+        _add_common_arguments(engine_parser)
+        engine_module.add_arguments(engine_parser)
+
+    return parser
+
+
+def _resolve_entry(registry_path: Path, model_name: str) -> ModelEntry:
+    """Look up `model_name` in the registry at `registry_path`.
+
+    Raises:
+        ValueError: if `model_name` isn't in the registry.
+    """
+    registry = load_registry(registry_path)
+    entry = next((model for model in registry.models if model.name == model_name), None)
+    if entry is None:
+        raise ValueError(f"Model '{model_name}' not found in {registry_path}")
+
+    if "gpu" not in entry.node_types:
+        warnings.warn(
+            f"'{entry.name}' is not tagged with node_types: [gpu] in the registry.",
+            stacklevel=2,
+        )
+
+    return entry
+
+
+def _download(args: argparse.Namespace) -> None:
+    entry = _resolve_entry(args.registry, args.model_name)
+    model_path = ensure_model_downloaded(entry)
+    print(f"[INFO] Model downloaded on '{model_path}'.")
+
+
+def _serve(args: argparse.Namespace) -> int:
+    entry = _resolve_entry(args.registry, args.model_name)
+    engine_module = ENGINES[args.engine]
+    kwargs = {key: value for key, value in vars(args).items() if key not in _SERVE_OWN_ARGS}
+    return engine_module.serve(entry, **kwargs)
+
+
+def run(argv: list[str] | None = None) -> int:
+    """Console-script entry point: parse `argv` and dispatch to `download`/`serve`."""
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "download":
+        _download(args)
+        return 0
+    return _serve(args)

--- a/packages/backends/gpu-node/src/backends/gpu_node/download.py
+++ b/packages/backends/gpu-node/src/backends/gpu_node/download.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+from urllib.parse import urlparse
+
+from common.registry import ModelEntry
+from huggingface_hub import hf_hub_download
+
+
+def parse_hf_source_url(source_url: str) -> tuple[str, str]:
+    """Split a Hugging Face `.../<repo>/resolve/<revision>/<filename>` URL.
+
+    Returns:
+        A `(repo_id, filename)` tuple.
+
+    Raises:
+        ValueError: if `source_url` doesn't contain a `/resolve/<revision>/` segment.
+    """
+    path = urlparse(source_url).path.lstrip("/")
+    repo_id, separator, rest = path.partition("/resolve/")
+    _, _, filename = rest.partition("/")
+
+    if not separator or not repo_id or not filename:
+        raise ValueError(
+            f"Not a Hugging Face file URL (expected '.../resolve/<revision>/<filename>'): "
+            f"{source_url}"
+        )
+
+    return repo_id, filename
+
+
+def ensure_model_downloaded(entry: ModelEntry) -> Path:
+    """Return the local path to `entry`'s weights, downloading them if not already cached.
+
+    Where the weights land is entirely huggingface_hub's own decision (its default cache,
+    normally outside the repo) -- auth, cache location, transfer acceleration, and mirror
+    endpoint are all left to its environment variables (HF_TOKEN, HF_HOME/HF_HUB_CACHE,
+    HF_HUB_ENABLE_HF_TRANSFER, HF_ENDPOINT) rather than exposed as gpu-node flags. Every
+    caller (the `download` CLI command and both serving engines) resolves through this
+    same function, so they always agree on where a given model's file actually is.
+
+    Raises:
+        ValueError: if `entry.format` isn't `gguf` (the only format supported so far),
+            or `entry.source_url` isn't a recognizable Hugging Face file URL.
+    """
+    if entry.format != "gguf":
+        raise ValueError(f"Only the 'gguf' format is supported for download, got: {entry.format}")
+
+    repo_id, filename = parse_hf_source_url(str(entry.source_url))
+
+    local_path = hf_hub_download(repo_id=repo_id, filename=filename)
+    return Path(local_path)

--- a/packages/backends/gpu-node/src/backends/gpu_node/engines/__init__.py
+++ b/packages/backends/gpu-node/src/backends/gpu_node/engines/__init__.py
@@ -1,0 +1,14 @@
+"""Registry of available serving engines, keyed by the `gpu-node serve <engine>` name.
+
+Each engine module owns its own CLI surface: `HELP` (shown in `serve --help`'s
+subcommand list and as that engine's own `--help` description), `add_arguments(parser)`
+(registers its engine-specific flags), and `serve(entry, **kwargs)` (does the work, with
+kwargs matching the dests `add_arguments` registered). Adding a new engine is dropping in
+a module with that shape and one entry here -- `cli.py` never needs to change.
+"""
+
+from backends.gpu_node.engines import llama_cpp
+
+ENGINES = {
+    "llama-cpp": llama_cpp,
+}

--- a/packages/backends/gpu-node/src/backends/gpu_node/engines/__init__.py
+++ b/packages/backends/gpu-node/src/backends/gpu_node/engines/__init__.py
@@ -7,8 +7,9 @@ kwargs matching the dests `add_arguments` registered). Adding a new engine is dr
 a module with that shape and one entry here -- `cli.py` never needs to change.
 """
 
-from backends.gpu_node.engines import llama_cpp
+from backends.gpu_node.engines import llama_cpp, ollama
 
 ENGINES = {
     "llama-cpp": llama_cpp,
+    "ollama": ollama,
 }

--- a/packages/backends/gpu-node/src/backends/gpu_node/engines/llama_cpp.py
+++ b/packages/backends/gpu-node/src/backends/gpu_node/engines/llama_cpp.py
@@ -45,16 +45,19 @@ def add_arguments(parser: argparse.ArgumentParser) -> None:
 
 def build_command(
     model_path: Path,
+    model_name: str,
     port: int = DEFAULT_PORT,
     ngl: int = DEFAULT_NGL,
     ctx_size: int = DEFAULT_CTX_SIZE,
     llama_server_bin: str = DEFAULT_LLAMA_SERVER_BIN,
 ) -> list[str]:
-    """Assemble the `llama-server` argv for serving `model_path`."""
+    """Assemble the `llama-server` argv for serving `model_path` under `model_name`."""
     return [
         llama_server_bin,
         "-m",
         str(model_path),
+        "-a",
+        model_name,
         "--port",
         str(port),
         "-ngl",
@@ -77,5 +80,5 @@ def serve(
         The `llama-server` process's exit code.
     """
     model_path = ensure_model_downloaded(entry)
-    command = build_command(model_path, port, ngl, ctx_size, llama_server_bin)
+    command = build_command(model_path, entry.name, port, ngl, ctx_size, llama_server_bin)
     return subprocess.run(command).returncode

--- a/packages/backends/gpu-node/src/backends/gpu_node/engines/llama_cpp.py
+++ b/packages/backends/gpu-node/src/backends/gpu_node/engines/llama_cpp.py
@@ -1,0 +1,81 @@
+import argparse
+import subprocess
+from pathlib import Path
+
+from backends.gpu_node.download import ensure_model_downloaded
+from common.registry import ModelEntry
+
+HELP = "Serve via llama.cpp's llama-server, which runs in the foreground until stopped."
+
+DEFAULT_PORT = 8080
+# Offload all layers to GPU; lower this (or 0) on CPU-only or VRAM-constrained machines.
+DEFAULT_NGL = 99
+DEFAULT_CTX_SIZE = 4096
+DEFAULT_LLAMA_SERVER_BIN = "llama-server"
+
+
+def add_arguments(parser: argparse.ArgumentParser) -> None:
+    """Register llama-cpp's own `serve` flags on `parser`."""
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=DEFAULT_PORT,
+        help=f"Port llama-server listens on (default: {DEFAULT_PORT}).",
+    )
+    parser.add_argument(
+        "--ngl",
+        type=int,
+        default=DEFAULT_NGL,
+        help=f"GPU layers to offload, 0 = CPU only (default: {DEFAULT_NGL}).",
+    )
+    parser.add_argument(
+        "--ctx-size",
+        type=int,
+        default=DEFAULT_CTX_SIZE,
+        dest="ctx_size",
+        help=f"Context window size (default: {DEFAULT_CTX_SIZE}).",
+    )
+    parser.add_argument(
+        "--llama-server-bin",
+        default=DEFAULT_LLAMA_SERVER_BIN,
+        dest="llama_server_bin",
+        help=f"Path/name of the llama-server binary (default: {DEFAULT_LLAMA_SERVER_BIN}).",
+    )
+
+
+def build_command(
+    model_path: Path,
+    port: int = DEFAULT_PORT,
+    ngl: int = DEFAULT_NGL,
+    ctx_size: int = DEFAULT_CTX_SIZE,
+    llama_server_bin: str = DEFAULT_LLAMA_SERVER_BIN,
+) -> list[str]:
+    """Assemble the `llama-server` argv for serving `model_path`."""
+    return [
+        llama_server_bin,
+        "-m",
+        str(model_path),
+        "--port",
+        str(port),
+        "-ngl",
+        str(ngl),
+        "--ctx-size",
+        str(ctx_size),
+    ]
+
+
+def serve(
+    entry: ModelEntry,
+    port: int = DEFAULT_PORT,
+    ngl: int = DEFAULT_NGL,
+    ctx_size: int = DEFAULT_CTX_SIZE,
+    llama_server_bin: str = DEFAULT_LLAMA_SERVER_BIN,
+) -> int:
+    """Download `entry` if needed and run `llama-server` in the foreground.
+
+    Returns:
+        The `llama-server` process's exit code.
+    """
+    model_path = ensure_model_downloaded(entry)
+    command = build_command(model_path, port, ngl, ctx_size, llama_server_bin)
+    return subprocess.run(command).returncode

--- a/packages/backends/gpu-node/src/backends/gpu_node/engines/ollama.py
+++ b/packages/backends/gpu-node/src/backends/gpu_node/engines/ollama.py
@@ -1,0 +1,57 @@
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+from backends.gpu_node.download import ensure_model_downloaded
+from common.registry import ModelEntry
+
+HELP = (
+    "Import into Ollama's already-running background service and return -- there is no "
+    "per-model process to hold open."
+)
+
+DEFAULT_OLLAMA_BIN = "ollama"
+DEFAULT_ENDPOINT = "http://localhost:11434/v1/chat/completions"
+
+
+def add_arguments(parser: argparse.ArgumentParser) -> None:
+    """Register ollama's own `serve` flags on `parser`."""
+    parser.add_argument(
+        "--ollama-bin",
+        default=DEFAULT_OLLAMA_BIN,
+        dest="ollama_bin",
+        help=f"Path/name of the ollama binary (default: {DEFAULT_OLLAMA_BIN}).",
+    )
+
+
+def build_modelfile(model_path: Path) -> str:
+    """Return the `Modelfile` content pointing Ollama at a local GGUF file."""
+    return f"FROM {model_path}\n"
+
+
+def serve(entry: ModelEntry, ollama_bin: str = DEFAULT_OLLAMA_BIN) -> int:
+    """Download `entry` if needed, import it into Ollama, and report where it's served.
+
+    The `Modelfile` is only a one-time pointer consumed by `ollama create` -- it's
+    written next to the downloaded weights (not left anywhere in the repo) and isn't
+    cleaned up afterward.
+
+    Returns:
+        The `ollama create` process's exit code (`0` on success).
+    """
+    model_path = ensure_model_downloaded(entry)
+    modelfile_path = model_path.parent / "Modelfile"
+    modelfile_path.write_text(build_modelfile(model_path))
+
+    result = subprocess.run([ollama_bin, "create", entry.name, "-f", str(modelfile_path)])
+
+    if result.returncode != 0:
+        return result.returncode
+
+    print(
+        f"'{entry.name}' is served by Ollama at {DEFAULT_ENDPOINT} "
+        f'(request body: {{"model": "{entry.name}", ...}}).',
+        file=sys.stderr,
+    )
+    return 0

--- a/packages/backends/gpu-node/tests/conftest.py
+++ b/packages/backends/gpu-node/tests/conftest.py
@@ -1,0 +1,24 @@
+import pytest
+import yaml
+from model_entry_factory import DEFAULT_MODEL_ENTRY_FIELDS
+
+_REGISTRY_YAML = yaml.safe_dump({"models": [DEFAULT_MODEL_ENTRY_FIELDS]})
+_REGISTRY_YAML_NON_GPU = yaml.safe_dump(
+    {"models": [{**DEFAULT_MODEL_ENTRY_FIELDS, "node_types": ["edge"]}]}
+)
+
+
+@pytest.fixture
+def registry_path(tmp_path):
+    """A `models.yaml` registry containing one gpu-tagged entry: `qwen3-1.7b-q4`."""
+    path = tmp_path / "models.yaml"
+    path.write_text(_REGISTRY_YAML)
+    return path
+
+
+@pytest.fixture
+def non_gpu_registry_path(tmp_path):
+    """Same registry as `registry_path`, but `qwen3-1.7b-q4` is tagged `node_types: [edge]`."""
+    path = tmp_path / "models.yaml"
+    path.write_text(_REGISTRY_YAML_NON_GPU)
+    return path

--- a/packages/backends/gpu-node/tests/model_entry_factory.py
+++ b/packages/backends/gpu-node/tests/model_entry_factory.py
@@ -1,0 +1,18 @@
+from common.registry import ModelEntry
+
+DEFAULT_SOURCE_URL = "https://huggingface.co/org/repo/resolve/main/model.gguf"
+DEFAULT_MODEL_ENTRY_FIELDS = {
+    "name": "qwen3-1.7b-q4",
+    "family": "qwen3",
+    "quantization": "Q4_K_M",
+    "size_b": 1.7,
+    "format": "gguf",
+    "node_types": ["gpu"],
+    "source_url": DEFAULT_SOURCE_URL,
+    "approx_vram_gb": 1.5,
+}
+
+
+def make_model_entry(**overrides) -> ModelEntry:
+    """Build a valid `ModelEntry` for tests; `overrides` replace any default field."""
+    return ModelEntry.model_validate({**DEFAULT_MODEL_ENTRY_FIELDS, **overrides})

--- a/packages/backends/gpu-node/tests/test_cli.py
+++ b/packages/backends/gpu-node/tests/test_cli.py
@@ -1,0 +1,65 @@
+import pytest
+from backends.gpu_node import cli
+
+
+def test_download_writes_model_path_on_success(registry_path, monkeypatch, capsys):
+    model_path = "/cache/model.gguf"
+    monkeypatch.setattr(cli, "ensure_model_downloaded", lambda entry: model_path)
+
+    exit_code = cli.run(["download", "qwen3-1.7b-q4", "--registry", str(registry_path)])
+
+    assert exit_code == 0
+    assert model_path in capsys.readouterr().out
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["download", "does-not-exist"],
+        ["serve", "llama-cpp", "does-not-exist"],
+    ],
+    ids=["download", "serve"],
+)
+def test_unknown_model_raises(registry_path, argv):
+    with pytest.raises(ValueError, match="not found"):
+        cli.run([*argv, "--registry", str(registry_path)])
+
+
+def test_resolve_entry_warns_when_not_tagged_gpu(non_gpu_registry_path):
+    with pytest.warns(UserWarning, match="node_types"):
+        entry = cli._resolve_entry(non_gpu_registry_path, "qwen3-1.7b-q4")
+
+    assert entry.name == "qwen3-1.7b-q4"
+
+
+@pytest.mark.parametrize(
+    ("engine_name", "extra_argv", "expected_kwargs"),
+    [
+        (
+            "llama-cpp",
+            ["--port", "9000"],
+            {"port": 9000, "ngl": 99, "ctx_size": 4096, "llama_server_bin": "llama-server"},
+        ),
+        ("ollama", [], {"ollama_bin": "ollama"}),
+    ],
+    ids=["llama-cpp", "ollama"],
+)
+def test_serve_dispatches_to_selected_engine_on_success(
+    registry_path, monkeypatch, engine_name, extra_argv, expected_kwargs
+):
+    captured = {}
+
+    def fake_serve(entry, **kwargs):
+        captured["entry"] = entry
+        captured["kwargs"] = kwargs
+        return 0
+
+    monkeypatch.setattr(cli.ENGINES[engine_name], "serve", fake_serve)
+
+    exit_code = cli.run(
+        ["serve", engine_name, "qwen3-1.7b-q4", "--registry", str(registry_path), *extra_argv]
+    )
+
+    assert exit_code == 0
+    assert captured["entry"].name == "qwen3-1.7b-q4"
+    assert captured["kwargs"] == expected_kwargs

--- a/packages/backends/gpu-node/tests/test_download.py
+++ b/packages/backends/gpu-node/tests/test_download.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+
+import pytest
+from backends.gpu_node import download
+from model_entry_factory import make_model_entry
+
+VALID_URL = (
+    "https://huggingface.co/bartowski/Qwen_Qwen3-1.7B-GGUF/resolve/main/Qwen_Qwen3-1.7B-Q4_K_M.gguf"
+)
+
+
+def test_parse_hf_source_url_splits_repo_and_filename():
+    repo_id, filename = download.parse_hf_source_url(VALID_URL)
+
+    assert repo_id == "bartowski/Qwen_Qwen3-1.7B-GGUF"
+    assert filename == "Qwen_Qwen3-1.7B-Q4_K_M.gguf"
+
+
+@pytest.mark.parametrize(
+    "malformed_url",
+    [
+        "https://huggingface.co/bartowski/Qwen_Qwen3-1.7B-GGUF",
+        "https://huggingface.co/bartowski/Qwen_Qwen3-1.7B-GGUF/resolve/main/",
+        "https://huggingface.co/resolve/main/model.gguf",
+    ],
+)
+def test_parse_hf_source_url_rejects_non_resolve_urls(malformed_url):
+    with pytest.raises(ValueError, match="Hugging Face file URL"):
+        download.parse_hf_source_url(malformed_url)
+
+
+@pytest.mark.parametrize("bad_format", ["safetensors", "awq", "gptq"])
+def test_ensure_model_downloaded_rejects_non_gguf_format(bad_format):
+    entry = make_model_entry(format=bad_format)
+
+    with pytest.raises(ValueError, match="gguf"):
+        download.ensure_model_downloaded(entry)
+
+
+def test_ensure_model_downloaded_calls_hf_hub_download_with_parsed_repo_and_filename(monkeypatch):
+    entry = make_model_entry(source_url=VALID_URL)
+    captured = {}
+
+    def fake_hf_hub_download(*, repo_id, filename):
+        captured["repo_id"] = repo_id
+        captured["filename"] = filename
+        return f"/cache/{filename}"
+
+    monkeypatch.setattr(download, "hf_hub_download", fake_hf_hub_download)
+
+    result = download.ensure_model_downloaded(entry)
+
+    assert captured["repo_id"] == "bartowski/Qwen_Qwen3-1.7B-GGUF"
+    assert captured["filename"] == "Qwen_Qwen3-1.7B-Q4_K_M.gguf"
+    assert result == Path("/cache/Qwen_Qwen3-1.7B-Q4_K_M.gguf")

--- a/packages/backends/gpu-node/tests/test_engines_llama_cpp.py
+++ b/packages/backends/gpu-node/tests/test_engines_llama_cpp.py
@@ -7,6 +7,7 @@ from backends.gpu_node.engines import llama_cpp
 from model_entry_factory import make_model_entry
 
 MODEL_PATH = Path("/models/model.gguf")
+MODEL_NAME = "qwen3-1.7b-q4"
 
 
 @pytest.mark.parametrize(
@@ -18,6 +19,8 @@ MODEL_PATH = Path("/models/model.gguf")
                 "llama-server",
                 "-m",
                 str(MODEL_PATH),
+                "-a",
+                MODEL_NAME,
                 "--port",
                 "8080",
                 "-ngl",
@@ -32,6 +35,8 @@ MODEL_PATH = Path("/models/model.gguf")
                 "/opt/llama-server",
                 "-m",
                 str(MODEL_PATH),
+                "-a",
+                MODEL_NAME,
                 "--port",
                 "9000",
                 "-ngl",
@@ -44,11 +49,11 @@ MODEL_PATH = Path("/models/model.gguf")
     ids=["defaults", "overrides"],
 )
 def test_build_command(kwargs, expected):
-    assert llama_cpp.build_command(MODEL_PATH, **kwargs) == expected
+    assert llama_cpp.build_command(MODEL_PATH, MODEL_NAME, **kwargs) == expected
 
 
 def test_serve_downloads_then_runs_llama_server_and_returns_exit_code(tmp_path, monkeypatch):
-    entry = make_model_entry()
+    entry = make_model_entry(name=MODEL_NAME)
     model_path = tmp_path / "model.gguf"
 
     monkeypatch.setattr(llama_cpp, "ensure_model_downloaded", lambda passed_entry: model_path)
@@ -59,4 +64,4 @@ def test_serve_downloads_then_runs_llama_server_and_returns_exit_code(tmp_path, 
     exit_code = llama_cpp.serve(entry, port=8081)
 
     assert exit_code == 7
-    mock_run.assert_called_once_with(llama_cpp.build_command(model_path, port=8081))
+    mock_run.assert_called_once_with(llama_cpp.build_command(model_path, MODEL_NAME, port=8081))

--- a/packages/backends/gpu-node/tests/test_engines_llama_cpp.py
+++ b/packages/backends/gpu-node/tests/test_engines_llama_cpp.py
@@ -1,0 +1,62 @@
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from backends.gpu_node.engines import llama_cpp
+from model_entry_factory import make_model_entry
+
+MODEL_PATH = Path("/models/model.gguf")
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "expected"),
+    [
+        (
+            {},
+            [
+                "llama-server",
+                "-m",
+                str(MODEL_PATH),
+                "--port",
+                "8080",
+                "-ngl",
+                "99",
+                "--ctx-size",
+                "4096",
+            ],
+        ),
+        (
+            {"port": 9000, "ngl": 20, "ctx_size": 2048, "llama_server_bin": "/opt/llama-server"},
+            [
+                "/opt/llama-server",
+                "-m",
+                str(MODEL_PATH),
+                "--port",
+                "9000",
+                "-ngl",
+                "20",
+                "--ctx-size",
+                "2048",
+            ],
+        ),
+    ],
+    ids=["defaults", "overrides"],
+)
+def test_build_command(kwargs, expected):
+    assert llama_cpp.build_command(MODEL_PATH, **kwargs) == expected
+
+
+def test_serve_downloads_then_runs_llama_server_and_returns_exit_code(tmp_path, monkeypatch):
+    entry = make_model_entry()
+    model_path = tmp_path / "model.gguf"
+
+    monkeypatch.setattr(llama_cpp, "ensure_model_downloaded", lambda passed_entry: model_path)
+
+    mock_run = MagicMock(return_value=subprocess.CompletedProcess(args=[], returncode=7))
+    monkeypatch.setattr(llama_cpp.subprocess, "run", mock_run)
+
+    exit_code = llama_cpp.serve(entry, port=8081)
+
+    assert exit_code == 7
+    mock_run.assert_called_once_with(llama_cpp.build_command(model_path, port=8081))

--- a/packages/backends/gpu-node/tests/test_engines_ollama.py
+++ b/packages/backends/gpu-node/tests/test_engines_ollama.py
@@ -1,0 +1,45 @@
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from backends.gpu_node.engines import ollama
+from model_entry_factory import make_model_entry
+
+
+def test_build_modelfile_points_at_local_path():
+    model_path = Path("/models/model.gguf")
+
+    assert ollama.build_modelfile(model_path) == f"FROM {model_path}\n"
+
+
+@pytest.mark.parametrize(
+    ("returncode", "expect_endpoint_message"),
+    [(0, True), (1, False)],
+    ids=["success", "failure"],
+)
+def test_serve_runs_ollama_create_and_reports_result(
+    tmp_path, monkeypatch, capsys, returncode, expect_endpoint_message
+):
+    entry = make_model_entry()
+    model_path = tmp_path / "model.gguf"
+    modelfile_path = tmp_path / "Modelfile"
+
+    monkeypatch.setattr(ollama, "ensure_model_downloaded", lambda passed_entry: model_path)
+
+    mock_run = MagicMock(return_value=subprocess.CompletedProcess(args=[], returncode=returncode))
+    monkeypatch.setattr(ollama.subprocess, "run", mock_run)
+
+    exit_code = ollama.serve(entry)
+
+    assert exit_code == returncode
+    # The Modelfile is written next to the model before `ollama create` runs, regardless
+    # of whether that command succeeds.
+    assert modelfile_path.read_text() == ollama.build_modelfile(model_path)
+    mock_run.assert_called_once_with(["ollama", "create", entry.name, "-f", str(modelfile_path)])
+
+    stderr = capsys.readouterr().err
+    if expect_endpoint_message:
+        assert ollama.DEFAULT_ENDPOINT in stderr
+    else:
+        assert stderr == ""

--- a/uv.lock
+++ b/uv.lock
@@ -103,9 +103,37 @@ wheels = [
 ]
 
 [[package]]
+name = "filelock"
+version = "3.32.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/30/03b03951873a1a0ffc7e8ca0e10c15597b59e8d0e39260704cd2ea087bc4/filelock-3.32.4.tar.gz", hash = "sha256:2bde2e4cf732e0153406d8a7bc80620ecf5e621fe0d25e41143c4e3b4733ff30", size = 222126, upload-time = "2026-08-23T17:37:55.363Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/01/a4/9b63d595d748e3aff8812b65eacc1a2c4bd90b7c2012e08e72373b4835eb/filelock-3.32.4-py3-none-any.whl", hash = "sha256:22e58ca3b1ae3b98993b762d7338367ae64fe50252bf78d59da3bfebcdf1cedd", size = 99864, upload-time = "2026-08-23T17:37:53.913Z" },
+]
+
+[[package]]
+name = "fsspec"
+version = "2026.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/78/f34251dadb8f3921264a1d9b8946f5e542014ee2614b285261b4e40e6775/fsspec-2026.7.0.tar.gz", hash = "sha256:c803c40f4cf860b49dea58ee3e1c33cb9c790520e233537e1340049f89b82a88", size = 317040, upload-time = "2026-07-28T16:34:51.052Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/3c/6a2bf344106328fd04963664a60b9bb6496fc25df8e962fcdc1367285fb9/fsspec-2026.7.0-py3-none-any.whl", hash = "sha256:b57ddbafedfaef7018c1ecab32aa200a9d7ca26b77965f64e48b70061249d279", size = 206583, upload-time = "2026-07-28T16:34:49.538Z" },
+]
+
+[[package]]
 name = "gpu-node"
 version = "0.1.0"
 source = { editable = "packages/backends/gpu-node" }
+dependencies = [
+    { name = "common" },
+    { name = "huggingface-hub" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "common", editable = "packages/common" },
+    { name = "huggingface-hub", specifier = ">=0.25" },
+]
 
 [[package]]
 name = "h11"
@@ -114,6 +142,30 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "hf-xet"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/ab/522a2ab67f27971a9d48ca666d4fca85ef7d5282d142e31fd087e27b1bbe/hf_xet-1.6.0.tar.gz", hash = "sha256:2e58454a340b3556dfa4972d5451aff4fba8dd42a236600ba1a1d2b1514f0fef", size = 920527, upload-time = "2026-08-03T22:33:13.243Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/62/3c062f593bd92ef4e77a0ef39541e3d82a0a1d3947c8a777a02a13a27828/hf_xet-1.6.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:70cbb9c896901600128cb9b6f06e132954fbede1db30f31f7c6c63f84cb7c31d", size = 4074584, upload-time = "2026-08-03T22:32:47.364Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/1e/c0ad437dd267a8e435bef594acf781bbc3874ff0b6435b4962d03ecf7cc4/hf_xet-1.6.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:23379c2f9ec8696d952b16414a2bae72cad86a52df869b050698ba60f538c675", size = 3867381, upload-time = "2026-08-03T22:32:49.049Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ee/7c0d7b6ab336167531b1c30af2af003f054af4c749becbd7209ae33a77c3/hf_xet-1.6.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f2f7278c05c22fd60cb436cda1269649b3e81db65ecdc8496e5e164aa4143e7b", size = 4453982, upload-time = "2026-08-03T22:32:50.568Z" },
+    { url = "https://files.pythonhosted.org/packages/63/06/ad8eab1c9525246650cbaa821caa3cdbaca734ab1a5b8c91bea09cbd8d69/hf_xet-1.6.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:948f15d3a9545cfe5932f6bd8b440f6ae630aee108f14b7bd6c561f7c2dcc522", size = 4249445, upload-time = "2026-08-03T22:32:52.391Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/26/1eee8aedb0dafc1ab9717dc9ac602cde33361b232dc06803f1f6ed18b58c/hf_xet-1.6.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5153e6bb103ad49d6ea9f1b2e230db5a2ea32551ad09a706d2f61d7c7c80d80e", size = 4451099, upload-time = "2026-08-03T22:32:54.114Z" },
+    { url = "https://files.pythonhosted.org/packages/67/57/0b88af1f194ab6c9c650547d9cc06bfeaab836ae4dcdb331676bfb8be95a/hf_xet-1.6.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:35cec30d75c6f9eb9c16a77cef68e85a103b72e24d4b473714ec9ff06428bab9", size = 4664712, upload-time = "2026-08-03T22:32:55.547Z" },
+    { url = "https://files.pythonhosted.org/packages/53/a0/26b717a9d1840e8abf48dcec64b5ed8fbe472671d38ad28d30e147132b33/hf_xet-1.6.0-cp314-cp314t-win_amd64.whl", hash = "sha256:5789835d7c6bc9436962853192082374297fb72d7eff7e7762ec25ceb7e25338", size = 4025906, upload-time = "2026-08-03T22:32:57.391Z" },
+    { url = "https://files.pythonhosted.org/packages/49/f6/4a9966633c6fef83af997e2cff68ec1963676d412bdfd096df2a93b8e185/hf_xet-1.6.0-cp314-cp314t-win_arm64.whl", hash = "sha256:75765820ce4700db3750c94acc8fe27c5fae4c9ec000a0dbac3ca082acf97765", size = 3849221, upload-time = "2026-08-03T22:32:59.123Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/50/7afa2c9c787405864fc47a0d1bbc02c62e9101947ed43c1f43899fc7d91d/hf_xet-1.6.0-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:633dc0cd71d32da58ab8c03ad38e2fac452c15c2b0a2866ebf6ededfe0a5061d", size = 4071729, upload-time = "2026-08-03T22:33:00.721Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/69/55b8dcf636142ae660fec1869fcac14c4da2e8412e14d6eee1523be77e9f/hf_xet-1.6.0-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:f0906082d9932ae0c0057fa194041c22b4e2cdb46b2592ef3b91f020d62a081a", size = 3876287, upload-time = "2026-08-03T22:33:02.251Z" },
+    { url = "https://files.pythonhosted.org/packages/67/4e/a28359bf1c1ecf11eba22123168c138698f7cb576ac678f5a2e16cd5da08/hf_xet-1.6.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d62671bb130879cef0ee4c9ebe47a14af6c66ec53e6d84dc15936e5ffdfac82f", size = 4464663, upload-time = "2026-08-03T22:33:03.802Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/69/1f0cbc2fb22ae6082d094f743d1b8945a3f36f6089cb95f42b7ee348cda7/hf_xet-1.6.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0e6e21fa3cdfcdcd76748564bf593870a5e013f47d97cf10aed63aa222cff5b7", size = 4262538, upload-time = "2026-08-03T22:33:05.287Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/3a/4f4f2301ade26e404462d3336fa11f7958d914cabbabdd6e03c3c5d5658c/hf_xet-1.6.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4fc74352a17015bd0ee90038bc9efe38db894cde45f268b6712b04fce8cd0acb", size = 4460520, upload-time = "2026-08-03T22:33:06.81Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/5f/311725e2a905534dfee2dcb5b08414f249147f1f12252bfc2bd24caa075c/hf_xet-1.6.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:8fb4f71cba6129110c3374a33f919001ff130488fc23553698e34cc1c2a1198c", size = 4675937, upload-time = "2026-08-03T22:33:08.616Z" },
+    { url = "https://files.pythonhosted.org/packages/98/b7/8c59a66d15205024662f1d66968136f13893f96df1ddc5087e2e281fc95f/hf_xet-1.6.0-cp38-abi3-win_amd64.whl", hash = "sha256:fb4fadde1b2b70bf4c0c14a6dccbe7194b1c28947fefd5bbe3fed9d940676c3b", size = 4033128, upload-time = "2026-08-03T22:33:10.171Z" },
+    { url = "https://files.pythonhosted.org/packages/73/63/ca511b6f802f28cf3489b280fe77475bcca8de85e81a6299d7916b5b5555/hf_xet-1.6.0-cp38-abi3-win_arm64.whl", hash = "sha256:3dc3e35441ba395006af5aaacc40ef2e603c51ef46c3530b9156185f00935ea3", size = 3859359, upload-time = "2026-08-03T22:33:11.725Z" },
 ]
 
 [[package]]
@@ -142,6 +194,26 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "huggingface-hub"
+version = "1.29.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64'" },
+    { name = "httpx" },
+    { name = "packaging" },
+    { name = "pyyaml" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/35/42316e8f6908b6d21bc8df017cc6efba94fb5edbf99b64e28dd142325e20/huggingface_hub-1.29.0.tar.gz", hash = "sha256:6ebb385a581435325cf6d5c5b233d5d4bc91175834d99fd65dae14379b36e9ad", size = 963121, upload-time = "2026-08-27T12:18:37.432Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4e/a5/47c2ea9b228ccbcba8467e9a64823146e8ebbad29855e591d8f5eedcc9c7/huggingface_hub-1.29.0-py3-none-any.whl", hash = "sha256:b00f7782afc14db4bc6572763810a635bdfbab8623d957bfb553bd18e03852cd", size = 795768, upload-time = "2026-08-27T12:18:35.431Z" },
 ]
 
 [[package]]
@@ -486,6 +558,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b5/b4/205b0d5241d934e8add0c38aa924c4f9fb7330834ff11e5444db964ec3f9/starlette-1.6.0.tar.gz", hash = "sha256:d4e3ac5e546444960c710297a3c9fc3f7ebae1b7e963f3d36173b49da535be9b", size = 2716969, upload-time = "2026-08-08T18:27:57.512Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/cb/6a6a47d5b464bd08695d254f3da6e7986cc70c9fa5d778eda57538edfe56/starlette-1.6.0-py3-none-any.whl", hash = "sha256:a86dd39d14bb45f85a3d18525215a9ef0cfd1f192ac793220e72598c90335f0c", size = 75969, upload-time = "2026-08-08T18:27:56.196Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.70.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/3b/6c24bec5be5e743ffd99576daa5cc077722fc7d5bbc00bd133fa0c698dc6/tqdm-4.70.0.tar.gz", hash = "sha256:55b0b0dbd97462d06ebee91e4dac24ed4d4702be82b24f07e6c1d27e08cea220", size = 795438, upload-time = "2026-07-27T11:33:15.271Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/1c/01bfd571a64e7f270e6bab5e33777debe0edc56759233ce84f27dec92d14/tqdm-4.70.0-py3-none-any.whl", hash = "sha256:7f585706bfddbdebf89daac705b2dfcc16890130727d3197ca62c732b4310953", size = 80184, upload-time = "2026-07-27T11:33:13.167Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds a `download.py` module that resolves a registry entry's weights through huggingface_hub, leaving auth/cache/mirror configuration to its own standard environment variables (`HF_TOKEN`, `HF_HOME`/`HF_HUB_CACHE`, etc.) instead of custom flags, so `download` and both serving engines always agree on where a model's weights actually live.
- Adds two serving engines, each owning its own CLI flags and defaults: `llama-cpp` (runs `llama-server` in the foreground) and `ollama` (imports the model into Ollama's already-running background service and returns). Adding a future engine only means dropping in a module with the same shape and one entry in the registry — `cli.py` never has to change.
- Wires up the `gpu-node` console script with two subcommands: `gpu-node download <model>` (weights only) and `gpu-node serve <engine> <model>` (download-if-needed + launch), plus a package README documenting flags, VRAM/tokens-per-sec placeholders, and the manual contract-compliance check.

## Linked issue

Closes #13

## Test plan

- [ ] Run `uv run gpu-node serve llama-cpp <model>` (or `ollama`) against a real `llama-server`/Ollama install on 4GB-class hardware and confirm the response validates against the OpenAI-compatible contract, per the package README's "Verifying contract compliance" section (not exercised in CI — no GPU or engine binaries on the runner).
