### PR TITLE
Register Qwen3 8B Q4_K_S in the model registry for the 6GB GPU node

### DIFF
--- a/configs/models.yaml
+++ b/configs/models.yaml
@@ -7,3 +7,11 @@ models:
     node_types: [gpu]
     source_url: https://huggingface.co/bartowski/Qwen_Qwen3-1.7B-GGUF/resolve/main/Qwen_Qwen3-1.7B-Q4_K_M.gguf
     approx_vram_gb: 1.5860
+  - name: qwen3-8b-q4
+    family: qwen3
+    quantization: Q4_K_S
+    size_b: 8
+    format: gguf
+    node_types: [gpu]
+    source_url: https://huggingface.co/bartowski/Qwen_Qwen3-8B-GGUF/resolve/main/Qwen_Qwen3-8B-Q4_K_S.gguf
+    approx_vram_gb: 4.7793


### PR DESCRIPTION
> This branch is stacked on `feat/gpu-node-scaffold`, so it targets that branch and its diff is a single commit. GitHub retargets it to `main` automatically once #39 merges.

## Summary

- Adds `qwen3-8b-q4` to `configs/models.yaml`: Qwen3 8B at Q4_K_S, the first registry entry that deliberately does not fit the team's ~4GB nodes. It exists to exercise the one node with 6GB of headroom, and to show the registry isn't pinned to the lowest common denominator.
- Q4_K_S rather than Q4_K_M because the larger quant plus a 4096-token KV cache leaves no room on a 6GB card, and rather than the smaller i-quants because Pascal has no fast dequant path for those, which would distort the throughput this entry exists to measure.
- `approx_vram_gb` is a measured value (4.7793), taken with the `nvidia-smi` delta method documented in `configs/README.md`, not an estimate derived from the file size.

## Linked issue

Closes #40

## Test plan

- [x] Both registry entries served end to end on the GTX 1060 6GB (Pascal, compute capability 6.1) via llama.cpp, 4096 context, full GPU offload, same 9-token prompt:

  | Entry | VRAM | Generation | Prompt eval |
  |---|---|---|---|
  | `qwen3-1.7b-q4` (Q4_K_M) | 1.59 GB | 66.56 tok/s | 65.58 tok/s |
  | `qwen3-8b-q4` (Q4_K_S) | 4.78 GB | 24.38 tok/s | 27.22 tok/s |

  Neither run hit an out-of-memory error or fell back to CPU, and the 8B was listening 3.65 s after start. Generation slows by 2.73x while the memory footprint grows by 3.01x, which is the signature of bandwidth-bound decoding — useful input for routing, since it means throughput on this class of GPU tracks the resident model size rather than the parameter count.

- [x] `uv run gpu-node download qwen3-8b-q4` resolves the source URL and caches the weights from a clean cache.
