### PR TITLE
Prove the full chain end to end with a marked pytest suite and a CPU-only CI pipeline

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,110 @@
+name: Integration
+
+# Kept apart from ci.yml on purpose: this pipeline provisions a real inference server,
+# so it is slower and fails for reasons that have nothing to do with lint or unit tests.
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: integration-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Pinned: llama.cpp cuts a release per build and "latest" moves several times a day.
+  LLAMA_CPP_BUILD: b10679
+  REGISTRY_PATH: tests/integration/fixtures/registry.yaml
+  ORCHESTRATOR_PORT: "8000"
+  # Read straight from the environment by tests/integration/settings.py.
+  INTEGRATION_MODEL: smollm2-135m-q4
+  # CPU-only inference has no GPU to fall back on, so it gets more room than the default.
+  INTEGRATION_TIMEOUT_SECONDS: "300"
+
+jobs:
+  end-to-end:
+    name: End-to-end (${{ matrix.engine }}, CPU only)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Each engine carries its own serve flags and readiness probe, so adding one
+        # is adding an entry here -- the suite itself stays engine-agnostic.
+        include:
+          - engine: llama-cpp
+            serve_flags: --ngl 0
+            backend_health_url: http://localhost:8080/health
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv (package manager) with cache
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          python-version: "3.11"
+
+      - name: Install workspace dependencies
+        run: uv sync --all-packages
+
+      - name: Install llama-server (CPU-only build)
+        run: |
+          archive="llama-${LLAMA_CPP_BUILD}-bin-ubuntu-x64.tar.gz"
+          curl -sSfL -o "$archive" \
+            "https://github.com/ggml-org/llama.cpp/releases/download/${LLAMA_CPP_BUILD}/${archive}"
+          tar -xzf "$archive"
+          # The shared objects ship alongside the binaries, so the loader needs the
+          # same directory that PATH gets.
+          echo "${GITHUB_WORKSPACE}/llama-${LLAMA_CPP_BUILD}" >> "$GITHUB_PATH"
+          echo "LD_LIBRARY_PATH=${GITHUB_WORKSPACE}/llama-${LLAMA_CPP_BUILD}" >> "$GITHUB_ENV"
+
+      - name: Cache model weights
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/huggingface
+          key: hf-${{ env.INTEGRATION_MODEL }}
+
+      - name: Serve the model
+        run: |
+          uv run gpu-node serve ${{ matrix.engine }} "$INTEGRATION_MODEL" \
+            --registry "$REGISTRY_PATH" ${{ matrix.serve_flags }} > backend.log 2>&1 &
+          # Generous: a cache miss downloads the weights inside this step.
+          timeout 600 bash -c \
+            'until curl -sf "${{ matrix.backend_health_url }}" > /dev/null; do sleep 2; done'
+
+      - name: Start the orchestrator
+        run: |
+          uv run uvicorn orchestrator.main:app --port "$ORCHESTRATOR_PORT" \
+            > orchestrator.log 2>&1 &
+          timeout 60 bash -c \
+            'until curl -sf "http://localhost:${ORCHESTRATOR_PORT}/health" > /dev/null; do
+               sleep 1
+             done'
+
+      - name: Run the integration suite
+        run: uv run pytest -m integration -v
+
+      - name: Dump server logs
+        if: failure()
+        run: |
+          echo "::group::backend"
+          cat backend.log || true
+          echo "::endgroup::"
+          echo "::group::orchestrator"
+          cat orchestrator.log || true
+          echo "::endgroup::"
+
+  # One stable check name to protect the branch with.
+  integration:
+    name: Integration
+    runs-on: ubuntu-latest
+    needs: end-to-end
+    if: always()
+    steps:
+      - name: Fail if any engine failed
+        run: |
+          if [ "${{ needs.end-to-end.result }}" != "success" ]; then
+            echo "end-to-end: ${{ needs.end-to-end.result }}"
+            exit 1
+          fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,5 +34,10 @@ line-length = 100
 select = ["E", "W", "F", "I"]
 
 [tool.pytest.ini_options]
-testpaths = ["packages"]
+testpaths = ["packages", "tests"]
 asyncio_mode = "auto"
+markers = [
+    "integration: exercises a live orchestrator and backend instead of mocked ones",
+]
+# Integration tests need a running stack, so a plain `uv run pytest` skips them.
+addopts = "-m 'not integration'"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,122 @@
+import time
+from collections.abc import Iterator
+
+import httpx
+import pytest
+from common.contract import ChatCompletionRequest, ChatCompletionResponse, Message
+from helpers import (
+    BODY_EXCERPT_CHARS,
+    CHAT_COMPLETIONS_PATH,
+    MAX_TOKENS,
+    PROMPT,
+    RawCompletion,
+    orchestrator_request,
+)
+from pydantic import ValidationError
+from settings import IntegrationSettings
+
+MEASUREMENT_KEY = pytest.StashKey[str]()
+
+
+def _format_measurement(completion: RawCompletion, settings: IntegrationSettings) -> str:
+    """Summarise what the live completion cost, for the end-of-run report.
+
+    This is latency as the *client* sees it, so it includes the gateway's own overhead.
+    The orchestrator's own per-request logging measures the server side; the gap between
+    the two is the interesting part, which is why this stays even once that exists.
+    """
+    usage = completion.body.get("usage", {})
+    prompt_tokens = usage.get("prompt_tokens")
+    completion_tokens = usage.get("completion_tokens")
+    latency = completion.latency_seconds
+
+    summary = f"{settings.model} - {latency:.2f}s"
+    if prompt_tokens is None or completion_tokens is None:
+        return f"{summary}, token counts missing from the response"
+
+    rate = f", {completion_tokens / latency:.1f} tok/s" if completion_tokens else ""
+    return (
+        f"{summary}, {prompt_tokens} prompt + {completion_tokens} completion "
+        f"= {prompt_tokens + completion_tokens} tokens{rate}"
+    )
+
+
+@pytest.fixture(scope="session")
+def settings() -> IntegrationSettings:
+    """Read the suite's configuration from the environment, or say what is missing.
+
+    Loaded lazily in a fixture rather than at import time: collection happens even for
+    a plain `uv run pytest` that deselects these tests, and that must not fail just
+    because the environment is not set up for a live run.
+    """
+    try:
+        return IntegrationSettings()
+    except ValidationError as exc:
+        pytest.fail(
+            "Integration settings are incomplete. Set INTEGRATION_MODEL to a model name "
+            f"from configs/models.yaml that the running backend serves.\n\n{exc}"
+        )
+
+
+@pytest.fixture(scope="session")
+def client(settings: IntegrationSettings) -> Iterator[httpx.Client]:
+    with httpx.Client(timeout=settings.timeout_seconds) as session_client:
+        yield session_client
+
+
+@pytest.fixture(scope="session")
+def raw_completion(
+    client: httpx.Client, settings: IntegrationSettings, pytestconfig: pytest.Config
+) -> Iterator[RawCompletion]:
+    """Send the single real completion the suite inspects, then record what it cost.
+
+    Session-scoped because generating from a real model is the expensive part of the
+    run: every assertion about the response reads this one result.
+    """
+    request = ChatCompletionRequest(
+        model=settings.model,
+        messages=[Message(role="user", content=PROMPT)],
+        max_tokens=MAX_TOKENS,
+        temperature=0.0,
+    )
+
+    started = time.perf_counter()
+    response = orchestrator_request(
+        client,
+        "POST",
+        f"{settings.orchestrator_url}{CHAT_COMPLETIONS_PATH}",
+        json=request.model_dump(mode="json"),
+    )
+    elapsed = time.perf_counter() - started
+
+    # The forwarder turns an unreachable backend into a 502 already naming the backend
+    # URL and the connection error, so its detail is passed through rather than restated.
+    if response.status_code == 502:
+        pytest.fail(response.json().get("detail", "the backend could not be reached"))
+
+    if response.status_code != 200:
+        pytest.fail(
+            f"{CHAT_COMPLETIONS_PATH} returned HTTP {response.status_code}, expected 200: "
+            f"{response.text[:BODY_EXCERPT_CHARS]}"
+        )
+
+    completion = RawCompletion(body=response.json(), latency_seconds=elapsed)
+    yield completion
+    pytestconfig.stash[MEASUREMENT_KEY] = _format_measurement(completion, settings)
+
+
+@pytest.fixture(scope="session")
+def completion(raw_completion: RawCompletion) -> ChatCompletionResponse:
+    """The live completion parsed through the shared contract."""
+    return ChatCompletionResponse.model_validate(raw_completion.body)
+
+
+def pytest_terminal_summary(terminalreporter: pytest.TerminalReporter) -> None:
+    """Report the measurement where it gets read: the end of the run, pass or fail.
+
+    Printed rather than written to a file so an ordinary run leaves nothing behind.
+    """
+    measurement = terminalreporter.config.stash.get(MEASUREMENT_KEY, None)
+    if measurement is not None:
+        terminalreporter.write_sep("-", "measured")
+        terminalreporter.write_line(measurement)

--- a/tests/integration/fixtures/registry.yaml
+++ b/tests/integration/fixtures/registry.yaml
@@ -1,0 +1,20 @@
+# Registry used only by the integration pipeline. It is deliberately separate from
+# configs/models.yaml so CI scaffolding stays out of the shipped model catalogue.
+#
+# The model is the smallest instruct GGUF that still produces a real completion
+# (~105 MB), because the pipeline validates the wiring, not inference quality.
+
+backends:
+  gpu: http://localhost:8080
+
+models:
+  - name: smollm2-135m-q4
+    family: smollm2
+    quantization: Q4_K_M
+    size_b: 0.135
+    format: gguf
+    # There is no CPU node type in the schema, and the pipeline exercises the GPU
+    # backend's code path -- just with every layer left on the CPU (-ngl 0).
+    node_types: [gpu]
+    source_url: https://huggingface.co/unsloth/SmolLM2-135M-Instruct-GGUF/resolve/main/SmolLM2-135M-Instruct-Q4_K_M.gguf
+    approx_vram_gb: 0.11

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,0 +1,35 @@
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+import pytest
+
+CHAT_COMPLETIONS_PATH = "/v1/chat/completions"
+
+PROMPT = "Reply with the single word: pong."
+MAX_TOKENS = 32
+
+# Enough of a failing body to diagnose from, short enough to read in a CI log.
+BODY_EXCERPT_CHARS = 200
+
+
+@dataclass
+class RawCompletion:
+    """One live completion and what it cost, before the contract is applied to it."""
+
+    body: dict
+    latency_seconds: float
+
+
+def orchestrator_request(
+    client: httpx.Client, method: str, url: str, **kwargs: Any
+) -> httpx.Response:
+    """Send a request to the orchestrator, failing with a startup hint if it is not up.
+
+    A refused connection is the most common way this suite is run wrong, so it gets a
+    message naming the command that fixes it rather than a bare `ConnectError`.
+    """
+    try:
+        return client.request(method, url, **kwargs)
+    except httpx.RequestError as exc:
+        pytest.fail(f"Orchestrator unreachable at {url}: {exc}.")

--- a/tests/integration/settings.py
+++ b/tests/integration/settings.py
@@ -1,0 +1,28 @@
+from pydantic import field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class IntegrationSettings(BaseSettings):
+    """Everything the integration suite reads from the environment."""
+
+    model_config = SettingsConfigDict(env_prefix="INTEGRATION_")
+
+    model: str
+    """Registry name of the model under test.
+
+    Deliberately has no default. The right value depends on what the local stack is
+    actually serving, and a default would silently point the suite at the wrong model
+    and report a mismatch that looks like a backend bug.
+    """
+
+    orchestrator_url: str = "http://localhost:8000"
+    """Base URL of the gateway under test."""
+
+    timeout_seconds: float = 120.0
+    """Per-request timeout. CPU-only inference is far slower than GPU, so CI raises it."""
+
+    @field_validator("orchestrator_url")
+    @classmethod
+    def _strip_trailing_slash(cls, value: str) -> str:
+        """Paths are joined onto this, so a trailing slash would produce a double slash."""
+        return value.rstrip("/")

--- a/tests/integration/test_end_to_end.py
+++ b/tests/integration/test_end_to_end.py
@@ -1,0 +1,55 @@
+import httpx
+import pytest
+from common.contract import ChatCompletionResponse
+from helpers import CHAT_COMPLETIONS_PATH, PROMPT, RawCompletion, orchestrator_request
+from settings import IntegrationSettings
+
+pytestmark = pytest.mark.integration
+
+UNKNOWN_MODEL = "definitely-not-a-registered-model"
+
+
+def test_health_reports_ok(client: httpx.Client, settings: IntegrationSettings) -> None:
+    response = orchestrator_request(client, "GET", f"{settings.orchestrator_url}/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_completion_matches_the_shared_contract(raw_completion: RawCompletion) -> None:
+    """A response off a real engine -- extra unmodeled fields and all -- must validate."""
+    ChatCompletionResponse.model_validate(raw_completion.body)
+
+
+def test_usage_accounts_for_every_token(completion: ChatCompletionResponse) -> None:
+    usage = completion.usage
+
+    assert usage.prompt_tokens > 0
+    assert usage.completion_tokens > 0
+    assert usage.total_tokens == usage.prompt_tokens + usage.completion_tokens
+
+
+def test_completion_returns_non_empty_content(completion: ChatCompletionResponse) -> None:
+    assert completion.choices
+    assert completion.choices[0].message.content.strip()
+
+
+def test_completion_reports_the_requested_model(
+    completion: ChatCompletionResponse, settings: IntegrationSettings
+) -> None:
+    """The backend answers under the registry name, not the weights file it loaded."""
+    assert completion.model == settings.model
+
+
+def test_unknown_model_is_rejected(client: httpx.Client, settings: IntegrationSettings) -> None:
+    """An unregistered model must not reach a backend that would happily answer anyway."""
+    payload = {
+        "model": UNKNOWN_MODEL,
+        "messages": [{"role": "user", "content": PROMPT}],
+        "max_tokens": 1,
+    }
+    response = orchestrator_request(
+        client, "POST", f"{settings.orchestrator_url}{CHAT_COMPLETIONS_PATH}", json=payload
+    )
+
+    assert response.status_code == 404


### PR DESCRIPTION
## Summary

- Adds a pytest suite marked `integration` that exercises the full chain against a live stack, in place of the standalone script the issue originally described. It behaves as a black-box client — it only ever talks to the orchestrator — so it stays agnostic of the engine and model behind it, and the same six checks run against SmolLM2-135M on a CI runner or a real model on a GPU box. A plain `uv run pytest` still collects only the mocked unit tests.
- Adds a separate `Integration` workflow that provisions a real stack: a pinned llama.cpp CPU build, a 105 MB model, `gpu-node serve`, and the orchestrator, then runs the suite against them. Kept out of `ci.yml` because it is slower and fails for reasons unrelated to lint or unit tests. Its model lives in `tests/integration/fixtures/registry.yaml` so `configs/models.yaml` stays free of CI scaffolding.
- **This PR's own `Integration` check will be red, on purpose.** `test_unknown_model_is_rejected` asserts that an unregistered model returns 404, but the orchestrator does not resolve models against the registry yet, so it forwards the request and the backend answers 200. It is left failing rather than xfailed so it turns green by itself once #11 lands. `Integration` should not be made a required status check before then, or it would block every PR.

## Linked issue

Closes #16

## Test plan

- [x] Ran the suite against a live orchestrator backed by a stub returning llama.cpp-shaped responses: five checks pass, `test_unknown_model_is_rejected` fails exactly as described above.
- [x] Checked the failure modes report something actionable rather than a bare traceback — orchestrator down, backend down (the forwarder's own 502 detail is passed through), and `INTEGRATION_MODEL` unset.
- [x] Confirmed the marker selection works both ways: `uv run pytest` runs 32 unit tests with 6 deselected, `-m integration` selects the 6.
- [ ] Run against a real GPU stack and record the `measured` line.
- [x] Watch the first CI run closely. No engine binary has actually executed with this configuration yet, so two things are unverified: that the loader resolves llama.cpp's shared objects through `LD_LIBRARY_PATH` (they ship alongside the binaries in the tarball, which is why the path is set at all), and that 600s is enough for a cold model download plus load.
