### PR TITLE
Add an ADR convention and rework the issue-authoring rules

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -58,6 +58,22 @@ A new leaf package needs all of the following, or `uv sync` will not install it:
 3. An entry in the root `pyproject.toml`'s `[tool.uv.workspace] members` list.
 4. An entry in the root `pyproject.toml`'s `dependencies` plus a matching `[tool.uv.sources]` line (`<name> = { workspace = true }`). Without this last step the package is a recognized workspace *member* but a plain `uv sync` will not install it into the shared `.venv` (only `uv sync --all-packages` would). Note the root `dependencies` entry still uses the distribution name (`gpu-node`), not the import path.
 
+## Decision records
+
+Decisions that shape more than one package are written as ADRs (Architecture Decision Records): short markdown files under `docs/decisions/`, one decision per file, following `docs/decisions/TEMPLATE.md`.
+
+Write one when a choice constrains another package, or when someone will ask "why was it done this way?" months from now — not for every technical choice. Number them sequentially and never reuse a number, including for one that gets superseded.
+
+Each ADR carries a `Status`:
+
+- `Proposed` — written down and safe to build against; the team hasn't confirmed it yet.
+- `Accepted` — confirmed by the team.
+- `Superseded by NNNN` — replaced. The file stays: the reasoning is the point, not the outcome.
+
+`Proposed` is what lets dependent work start before the team has met. A decision that blocks everyone until it is ratified is the failure mode this status exists to prevent — write it, mark it `Proposed`, build against it, and let the evidence that confirms or corrects it arrive in its own task.
+
+Decisions about the team rather than the system — who owns what, hardware, cadence, budget — stay in the shared planning docs, not here. An ADR explains something a reader of this repository would otherwise have to guess.
+
 ## Conventions
 
 - All code and comments must be written in English. This covers identifiers (variables, functions, classes, modules), comments, docstrings, log/console messages, test names, and documentation. No mixed-language content.

--- a/.claude/skills/issue/SKILL.md
+++ b/.claude/skills/issue/SKILL.md
@@ -2,8 +2,9 @@
 name: issue
 description: This skill should be used when the user asks to "open an issue", "create an issue",
   "file a bug", "report a bug", or whenever Claude is about to run `gh issue create` in this
-  repository. Enforces this project's issue templates, labels, and confirmation workflow.
-version: 0.1.0
+  repository. Enforces this project's issue templates, granularity, title and metadata
+  conventions, and confirmation workflow.
+version: 0.2.0
 ---
 
 # Issues for meshcortex
@@ -12,23 +13,65 @@ Open GitHub issues in this repository with a consistent body and metadata, using
 templates under `.github/ISSUE_TEMPLATE/` so the structure holds regardless of which teammate's
 Claude Code session created it.
 
-## Before creating
+The sections below follow the order the work actually happens: decide how many issues there are,
+pick the template, write the title, write the body, set the metadata, confirm.
+
+## Splitting work into issues
+
+Format isn't the hard part of writing an issue; granularity is. Before creating a set of issues
+for a phase or an epic:
+
+- **Tests are not their own issue.** An issue that produces code carries its own tests. Splitting
+  them off makes one person wait on another for no technical reason, and the test issue is
+  blocked from the moment it is created.
+- **An issue that produces a definition** — a schema, a taxonomy, a contract — is verified by
+  applying it to real data, not by tests. Keep the definition and its first application in the
+  same issue: separated, the second one discovers the first is wrong and reopens it.
+- **One unit of code is one issue.** Selection, failure handling and the edge cases of the same
+  function belong together; three issues over one file means three PRs conflicting with each
+  other.
+- **When every member repeats the same work, open sibling issues, one per person**, following the
+  existing `Validate gpu-node on <name>'s GPU` pattern. Everyone owns something, and milestone
+  progress reflects real work.
+- **Check what the phase depends on that isn't decided yet**, and prefer the approach that stays
+  valid whichever way the open question resolves. Name that constraint in the issue instead of
+  letting it surface halfway through.
+- **A design decision ships as `Proposed`** (see Decision records in `CLAUDE.md`) so dependent
+  issues can start immediately. Ratifying it is its own issue, never a blocker on the first.
+
+## Choosing the template
 
 1. Pick the closest matching template (`bug_report.md`, `feature_request.md`, `epic.md`, or
    `roadmap_task.md`) rather than writing free-form. `gh issue create` doesn't apply a template's
    frontmatter automatically — pass the matching `--title`, `--label`, and `--type` explicitly.
-2. Read existing labels with `gh label list` rather than guessing a name. If nothing in the
-   templates fits, say so instead of forcing the closest match.
-3. Search for an existing issue covering the same problem before opening a new one
+2. Search for an existing issue covering the same problem before opening a new one
    (`gh issue list --search "..."`) to avoid duplicates.
+
+## Title
+
+Task titles start with an imperative verb — `Scaffold packages/orchestrator`, `Wire orchestrator
+to configs/models.yaml`. Epic titles are noun phrases — `Repo & tooling foundation` — because an
+epic is a thing, not an action. That difference is what makes the two levels scannable in the
+issue list.
+
+No phase name, no plan ID (`P0-01`), and no epic name in the title. The Milestone, the Issue Type
+and the parent relationship already encode all three; repeating one only means it has to be
+maintained in two places, and it goes stale the moment a phase or epic is renamed.
+
+If a task title needs "and", it is two issues — the same test the commit skill applies to a
+subject line. A conjunction in an epic title is fine, since grouping is exactly what an epic does.
 
 ## Body
 
-Follow the matching template's sections. Write as natural sentences/paragraphs — no manual
-line-wrapping, even in a temp `.md` file staged for `--body-file`: this overrides the global
-100-character prose-wrap preference, since GitHub renders a paragraph's internal line breaks as
-nothing (soft-wrapped) and hard-wrapping only makes the raw source look broken up for no visual
-benefit.
+Follow the matching template's sections, and use them as they are: if one doesn't apply, drop it,
+but don't invent new ones. If something is genuinely missing from every issue of a kind, change
+the template rather than the individual issue. A `Depends on` heading in particular duplicates the
+native relationship and goes stale silently.
+
+Write as natural sentences/paragraphs — no manual line-wrapping, even in a temp `.md` file staged
+for `--body-file`: this overrides the global 100-character prose-wrap preference, since GitHub
+renders a paragraph's internal line breaks as nothing (soft-wrapped) and hard-wrapping only makes
+the raw source look broken up for no visual benefit.
 
 Roadmap task and Epic issues must be self-contained: never reference a phase by name (that's
 already the Milestone, not prose), the parent Epic (that's the sub-issue relationship, not
@@ -40,19 +83,17 @@ isn't its parent.
 When referencing another issue, always use the real `#<number>` link — never a title-derived
 scheme like `P0-01`, which doesn't link to anything and breaks the moment the issue is retitled.
 An actual dependency is metadata, not body content: set it as a real Relationship instead
-(see Metadata below). For an issue that's merely related (no dependency either way), prefer the
-native "Relates to" relationship, web UI only for now (no `gh` CLI or GraphQL support yet), so
-tell the user to add it by hand rather than scripting it. Use a bare `#<number>` inline only
-when neither relationship type fits.
+(see Metadata below).
 
 ## Metadata
 
 Only set metadata if `gh` is available and the user has confirmed it.
 
-- Attach whatever labels fit, chosen from what `gh label list` actually returns — never a name
-  that wasn't confirmed to exist. There are no `phase:`/`epic:` labels in this repo; phase and
-  epic membership are expressed through Milestone and Issue Type + parent/sub-issue (below), not
-  labels.
+- Roadmap tasks and epics carry **no labels**: Issue Type, Milestone and the parent relationship
+  already classify them, and none of this repo's labels describe roadmap work. Labels belong on
+  `bug_report` and `feature_request` issues, where `bug` and `enhancement` genuinely apply — read
+  them with `gh label list` and never pass a name that wasn't confirmed to exist. There are no
+  `phase:`/`epic:` labels here, by design.
 - Set the Milestone (`--milestone`) from `gh api repos/:owner/:repo/milestones` if this issue
   belongs to a specific phase — never a name that wasn't confirmed to exist.
 - Set the Issue Type (`--type`) to match the chosen template's `type:` frontmatter — `gh issue
@@ -62,8 +103,10 @@ Only set metadata if `gh` is available and the user has confirmed it.
 - If this issue is blocked by, or blocks, another one, set that with the native Relationships
   feature — `--blocked-by`/`--blocking` on `gh issue create`, or `--add-blocked-by`/
   `--add-blocking` on `gh issue edit`.
-- If this issue is merely related to another (no dependency either way), flag that the user
-  should add the native "Relates to" relationship from the issue's web UI.
+- If this issue is merely related to another (no dependency either way), the native "Relates to"
+  relationship is web UI only for now — no `gh` CLI or GraphQL support — so tell the user to add
+  it by hand rather than scripting it. Use a bare `#<number>` inline in the body only when
+  neither relationship type fits.
 - Assign to whoever should own it; leave unassigned if that's unclear rather than guessing.
 - Don't add the issue to the "meshcortex roadmap" Project manually — the `Auto-add to project`
   workflow already does this for every open issue that matches its filter.
@@ -79,5 +122,6 @@ outward-facing and cannot be quietly undone.
 - `.github/ISSUE_TEMPLATE/bug_report.md`, `.github/ISSUE_TEMPLATE/feature_request.md`,
   `.github/ISSUE_TEMPLATE/epic.md`, `.github/ISSUE_TEMPLATE/roadmap_task.md` — the body templates
   this skill fills in.
+- `CLAUDE.md` — Decision records section, for the `Proposed`/`Accepted` status referenced above.
 - `.claude/skills/pull-request/SKILL.md` — companion skill for opening PRs that close these
   issues.

--- a/docs/decisions/TEMPLATE.md
+++ b/docs/decisions/TEMPLATE.md
@@ -1,0 +1,27 @@
+# NNNN. Noun phrase naming the decision
+
+## Status
+Proposed
+
+## Context
+What forced this decision. The constraint, the conflict, or the gap that made a choice
+necessary — enough that someone reading it in six months understands the situation without
+reconstructing it. State explicitly what this ADR does *not* cover, so a later one can pick
+that part up without overlapping.
+
+## Decision
+What was decided, in enough detail to build against. Use `###` subsections when the decision
+has distinct parts (a file layout, a schema, the types involved). Put the reason next to each
+non-obvious choice rather than collecting rationale in a section of its own.
+
+## Alternatives considered
+Each option that was genuinely on the table, and why it lost. An alternative listed without a
+reason for rejection is decoration — leave it out.
+
+## Open questions for the team
+What is still unresolved, and what would resolve it. An empty section is a valid answer; a
+stale list is worse than none.
+
+## Consequences
+What this makes easy, what it makes expensive, and what becomes a breaking change once other
+packages depend on it.


### PR DESCRIPTION
## Summary

- Adds `docs/decisions/TEMPLATE.md` and a Decision records section to `CLAUDE.md`. The repo already had an ADR but no convention behind it — no template, no numbering rule, and nothing explaining the `Status` field. The section says when a decision is worth an ADR and what `Proposed` is for: letting dependent work start before the team has ratified anything, which is what stops one decision from blocking a whole phase. It also draws the line between decisions about the system, which belong in the repo, and decisions about the team, which stay in the shared planning docs.

- Reworks the `issue` skill. It covered format and metadata thoroughly but said nothing about granularity or titles, which is where the expensive mistakes happen — a well-formatted set of badly split issues still costs the team weeks. New sections cover how to split work into issues and how to write a title, and the existing sections are reordered to match the order the work actually happens.

- The new rules come from auditing the issues that already exist rather than from a design guess. None of the 24 open and closed issues carried a label, so the instruction to pick one is reversed: labels now apply only to bug and feature reports, while Issue Type, Milestone and the parent relationship classify everything else. Three titles repeated the phase name the milestone already holds, and two invented sections the templates don't define.

## Test plan

- [x] Label rule checked against reality: `gh issue list --state all --json number,labels` returns no labels on any of the 24 issues, and every one carries an Issue Type (16 Task, 5 Epic, 1 Feature). The second half of the rule — that labels belong on bug and feature reports — has no evidence yet, since the repo has no bug reports and the single Feature is unlabelled too.
- [x] Template checked against `0001-model-registry-schema.md`: the section sequence matches exactly, including the `###` subsections under Decision. The title style did not match — the template asked for an imperative while the existing ADR uses a noun phrase — and the template was corrected to follow the ADR.
