### PR TITLE
Add mocked unit tests for the orchestrator's chat completions passthrough

### DIFF
--- a/packages/orchestrator/tests/conftest.py
+++ b/packages/orchestrator/tests/conftest.py
@@ -1,0 +1,28 @@
+"""Shared fixtures: an in-process orchestrator app pointed at a fake backend URL."""
+
+import httpx
+import pytest
+from orchestrator.main import app
+from orchestrator.settings import settings
+
+FAKE_BACKEND_URL = "http://backend.test"
+
+
+@pytest.fixture
+def backend_url(monkeypatch: pytest.MonkeyPatch) -> str:
+    """Point the orchestrator at a fake backend URL that respx can intercept."""
+    monkeypatch.setattr(settings, "backend_url", FAKE_BACKEND_URL)
+    return FAKE_BACKEND_URL
+
+
+@pytest.fixture
+async def client(backend_url: str):
+    """An async client talking to the orchestrator app in-process via ASGI.
+
+    Runs the app's lifespan (startup/shutdown) so `app.state.http_client`
+    exists, exactly as it would under a real server.
+    """
+    async with app.router.lifespan_context(app):
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(transport=transport, base_url="http://testserver") as ac:
+            yield ac

--- a/packages/orchestrator/tests/fixtures/chat_completion_response.json
+++ b/packages/orchestrator/tests/fixtures/chat_completion_response.json
@@ -1,0 +1,36 @@
+{
+  "id": "chatcmpl-3lrGixoa8arlIgrmb9yu29XdNYi11DSP",
+  "object": "chat.completion",
+  "created": 1786034702,
+  "model": "Qwen/Qwen2.5-0.5B-Instruct-GGUF:Q4_K_M",
+  "system_fingerprint": "b10229-c745be2a2",
+  "choices": [
+    {
+      "index": 0,
+      "finish_reason": "stop",
+      "message": {
+        "role": "assistant",
+        "content": "Recursion is a method where a function calls itself, often with a smaller or simpler problem, until a base case is reached, at which point it can return the result."
+      }
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 24,
+    "completion_tokens": 36,
+    "total_tokens": 60,
+    "prompt_tokens_details": {
+      "cached_tokens": 23
+    }
+  },
+  "timings": {
+    "cache_n": 23,
+    "prompt_n": 1,
+    "prompt_ms": 16.079,
+    "prompt_per_token_ms": 16.079,
+    "prompt_per_second": 62.19292244542571,
+    "predicted_n": 36,
+    "predicted_ms": 554.861,
+    "predicted_per_token_ms": 15.412805555555556,
+    "predicted_per_second": 64.88111436918435
+  }
+}

--- a/packages/orchestrator/tests/test_completions.py
+++ b/packages/orchestrator/tests/test_completions.py
@@ -1,0 +1,82 @@
+"""Tests for POST /v1/chat/completions: passthrough happy path and failure modes.
+
+The backend is never real -- every test mocks it with respx -- so this suite
+has zero network/GPU/model dependencies and runs in well under a second.
+"""
+
+import json
+from pathlib import Path
+
+import httpx
+from common.contract import ChatCompletionResponse
+from respx import MockRouter
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures"
+
+REQUEST_PAYLOAD = {
+    "model": "Qwen/Qwen2.5-0.5B-Instruct-GGUF:Q4_K_M",
+    "messages": [{"role": "user", "content": "Explain recursion briefly."}],
+}
+
+
+def _load_canned_response() -> dict:
+    """A real llama.cpp response, captured for the shared contract (see #7)."""
+    return json.loads((FIXTURES_DIR / "chat_completion_response.json").read_text())
+
+
+async def test_happy_path_returns_backend_response(
+    client: httpx.AsyncClient, backend_url: str, respx_mock: MockRouter
+) -> None:
+    """Contract in, contract out: a successful backend call is passed through as-is."""
+    respx_mock.post(f"{backend_url}/v1/chat/completions").mock(
+        return_value=httpx.Response(200, json=_load_canned_response())
+    )
+
+    response = await client.post("/v1/chat/completions", json=REQUEST_PAYLOAD)
+
+    assert response.status_code == 200
+    ChatCompletionResponse.model_validate(response.json())
+
+
+async def test_backend_unreachable_returns_502(
+    client: httpx.AsyncClient, backend_url: str, respx_mock: MockRouter
+) -> None:
+    """A connection failure to the backend surfaces as a clean 502, not a stack trace."""
+    respx_mock.post(f"{backend_url}/v1/chat/completions").mock(
+        side_effect=httpx.ConnectError("connection refused")
+    )
+
+    response = await client.post("/v1/chat/completions", json=REQUEST_PAYLOAD)
+
+    assert response.status_code == 502
+    assert backend_url in response.json()["detail"]
+
+
+async def test_backend_error_is_passed_through(
+    client: httpx.AsyncClient, backend_url: str, respx_mock: MockRouter
+) -> None:
+    """A backend-side error is forwarded as-is (status + body), never swallowed or rewrapped."""
+    respx_mock.post(f"{backend_url}/v1/chat/completions").mock(
+        return_value=httpx.Response(500, json={"error": "internal backend failure"})
+    )
+
+    response = await client.post("/v1/chat/completions", json=REQUEST_PAYLOAD)
+
+    assert response.status_code == 500
+    assert response.json() == {"error": "internal backend failure"}
+
+
+async def test_forwarded_payload_matches_the_request(
+    client: httpx.AsyncClient, backend_url: str, respx_mock: MockRouter
+) -> None:
+    """The orchestrator must not silently mutate the request on its way to the backend."""
+    route = respx_mock.post(f"{backend_url}/v1/chat/completions").mock(
+        return_value=httpx.Response(200, json=_load_canned_response())
+    )
+
+    await client.post("/v1/chat/completions", json=REQUEST_PAYLOAD)
+
+    forwarded_body = json.loads(route.calls.last.request.content)
+    assert forwarded_body["model"] == REQUEST_PAYLOAD["model"]
+    assert forwarded_body["messages"] == REQUEST_PAYLOAD["messages"]
+    assert forwarded_body["stream"] is False

--- a/packages/orchestrator/tests/test_health.py
+++ b/packages/orchestrator/tests/test_health.py
@@ -1,0 +1,11 @@
+"""Tests for GET /health."""
+
+import httpx
+
+
+async def test_health_returns_ok(client: httpx.AsyncClient) -> None:
+    """The liveness endpoint is trivially checkable: always 200, always this body."""
+    response = await client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,8 @@ dev = [
     # Pinned to match .pre-commit-config.yaml and CI (identical ruff everywhere).
     "ruff==0.16.1",
     "pytest>=8.0",
+    "pytest-asyncio>=0.24",
+    "respx>=0.21",
 ]
 
 [tool.ruff]
@@ -33,3 +35,4 @@ select = ["E", "W", "F", "I"]
 
 [tool.pytest.ini_options]
 testpaths = ["packages"]
+asyncio_mode = "auto"

--- a/uv.lock
+++ b/uv.lock
@@ -247,6 +247,8 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "respx" },
     { name = "ruff" },
 ]
 
@@ -260,6 +262,8 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-asyncio", specifier = ">=0.24" },
+    { name = "respx", specifier = ">=0.21" },
     { name = "ruff", specifier = "==0.16.1" },
 ]
 
@@ -459,6 +463,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.3"
 source = { registry = "https://pypi.org/simple" }
@@ -520,6 +537,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "respx"
+version = "0.23.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/98/4e55c9c486404ec12373708d015ebce157966965a5ebe7f28ff2c784d41b/respx-0.23.1.tar.gz", hash = "sha256:242dcc6ce6b5b9bf621f5870c82a63997e8e82bc7c947f9ffe272b8f3dd5a780", size = 29243, upload-time = "2026-04-08T14:37:16.008Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/4a/221da6ca167db45693d8d26c7dc79ccfc978a440251bf6721c9aaf251ac0/respx-0.23.1-py2.py3-none-any.whl", hash = "sha256:b18004b029935384bccfa6d7d9d74b4ec9af73a081cc28600fffc0447f4b8c1a", size = 25557, upload-time = "2026-04-08T14:37:14.613Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add `pytest-asyncio` and `respx` dev dependencies so the async orchestrator app can be tested without a real backend.
- Add `conftest.py`/`test_health.py`/`test_completions.py` covering `GET /health` and the `POST /v1/chat/completions` happy path, backend-unreachable (502), backend-error passthrough, and an assertion that the forwarded request body is unchanged.
- Skip the unknown-model → 404 case for now, since it depends on #11, which hasn't landed yet.

## Linked issue

Closes #12

## Test plan

- [x] `uv run pytest packages/orchestrator -v` passes in well under the ~10s ceiling from the issue (currently ~0.35s locally).
