### PR TITLE
feat(orchestrator): resolve backend from the model registry

### DIFF
--- a/configs/models.yaml
+++ b/configs/models.yaml
@@ -1,3 +1,6 @@
+backends:
+  gpu: http://localhost:8080
+
 models:
   - name: qwen3-1.7b-q4
     family: qwen3

--- a/packages/common/src/common/registry.py
+++ b/packages/common/src/common/registry.py
@@ -4,6 +4,8 @@ from typing import Literal
 import yaml
 from pydantic import BaseModel, HttpUrl, ValidationError, model_validator
 
+NodeType = Literal["gpu", "edge", "router"]
+
 
 class ModelEntry(BaseModel):
     name: str
@@ -11,13 +13,14 @@ class ModelEntry(BaseModel):
     quantization: str | None
     size_b: float
     format: Literal["gguf", "safetensors", "awq", "gptq"]
-    node_types: list[Literal["gpu", "edge", "router"]]
+    node_types: list[NodeType]
     source_url: HttpUrl
     approx_vram_gb: float | None = None
 
 
 class ModelRegistry(BaseModel):
     models: list[ModelEntry]
+    backends: dict[NodeType, HttpUrl] = {}
 
     @model_validator(mode="after")
     def no_duplicate_names(self):

--- a/packages/common/tests/test_registry.py
+++ b/packages/common/tests/test_registry.py
@@ -77,3 +77,20 @@ models:
 
     with pytest.raises(ValueError, match="node_types"):
         load_registry(yaml_file)
+
+
+def test_backends_parsed(tmp_path):
+    yaml_file = tmp_path / "models.yaml"
+    yaml_file.write_text("backends:\n  gpu: http://localhost:8080\nmodels: []\n")
+
+    registry = load_registry(yaml_file)
+
+    assert str(registry.backends["gpu"]).rstrip("/") == "http://localhost:8080"
+
+
+def test_invalid_backend_node_type(tmp_path):
+    yaml_file = tmp_path / "models.yaml"
+    yaml_file.write_text("backends:\n  cpu: http://localhost:8080\nmodels: []\n")
+
+    with pytest.raises(ValueError):
+        load_registry(yaml_file)

--- a/packages/orchestrator/src/orchestrator/forwarder.py
+++ b/packages/orchestrator/src/orchestrator/forwarder.py
@@ -1,19 +1,17 @@
-"""Forwards chat completion requests to the configured inference backend."""
+"""Forwards chat completion requests to a resolved inference backend."""
 
 import httpx
 from common.contract import ChatCompletionRequest
 from fastapi import HTTPException
 from fastapi.responses import JSONResponse
 
-from orchestrator.settings import settings
-
 CHAT_COMPLETIONS_PATH = "/v1/chat/completions"
 
 
 async def forward_chat_completion(
-    client: httpx.AsyncClient, request: ChatCompletionRequest
+    client: httpx.AsyncClient, backend_url: str, request: ChatCompletionRequest
 ) -> JSONResponse:
-    """Forward a validated chat completion request to `BACKEND_URL`.
+    """Forward a validated chat completion request to ``backend_url``.
 
     Returns the backend's response as-is (status code and JSON body) on
     success or on a backend-side error. Raises `HTTPException(502)` only
@@ -21,12 +19,12 @@ async def forward_chat_completion(
     """
     try:
         response = await client.post(
-            f"{settings.backend_url}{CHAT_COMPLETIONS_PATH}",
+            f"{backend_url}{CHAT_COMPLETIONS_PATH}",
             json=request.model_dump(mode="json"),
         )
     except httpx.RequestError as exc:
         raise HTTPException(
-            status_code=502, detail=f"Backend unreachable at {settings.backend_url}: {exc}"
+            status_code=502, detail=f"Backend unreachable at {backend_url}: {exc}"
         ) from exc
 
     try:

--- a/packages/orchestrator/src/orchestrator/main.py
+++ b/packages/orchestrator/src/orchestrator/main.py
@@ -4,15 +4,21 @@ from contextlib import asynccontextmanager
 
 import httpx
 from common.contract import ChatCompletionRequest
+from common.registry import load_registry
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 
 from orchestrator.forwarder import forward_chat_completion
+from orchestrator.resolution import ModelNotFoundError, resolve_backend
 from orchestrator.settings import settings
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    # Load the registry at startup. load_registry raises on a missing or invalid
+    # file, so the service fails fast with a clear error instead of starting in a
+    # broken state.
+    app.state.registry = load_registry(settings.registry_path)
     async with httpx.AsyncClient(timeout=settings.backend_timeout_seconds) as client:
         app.state.http_client = client
         yield
@@ -28,4 +34,11 @@ async def health() -> dict[str, str]:
 
 @app.post("/v1/chat/completions")
 async def chat_completions(request: ChatCompletionRequest) -> JSONResponse:
-    return await forward_chat_completion(app.state.http_client, request)
+    try:
+        backend_url = resolve_backend(app.state.registry, request.model)
+    except ModelNotFoundError as exc:
+        return JSONResponse(
+            status_code=404,
+            content={"error": f"model '{exc.model}' not found in registry"},
+        )
+    return await forward_chat_completion(app.state.http_client, backend_url, request)

--- a/packages/orchestrator/src/orchestrator/resolution.py
+++ b/packages/orchestrator/src/orchestrator/resolution.py
@@ -1,0 +1,38 @@
+"""Pure model-to-backend resolution for the orchestrator."""
+
+from common.registry import ModelRegistry
+
+
+class ModelNotFoundError(Exception):
+    """Raised when a requested model is not present in the registry."""
+
+    def __init__(self, model: str) -> None:
+        self.model = model
+        super().__init__(f"model '{model}' not found in registry")
+
+
+class BackendNotConfiguredError(Exception):
+    """Raised when a model's node type has no backend URL configured."""
+
+    def __init__(self, node_type: str) -> None:
+        self.node_type = node_type
+        super().__init__(f"no backend configured for node type '{node_type}'")
+
+
+def resolve_backend(registry: ModelRegistry, model: str) -> str:
+    """Return the backend base URL that serves ``model``.
+
+    Resolution uses the model's first listed node type. Pure function: no I/O.
+
+    Raises:
+        ModelNotFoundError: if no registry entry matches ``model``.
+        BackendNotConfiguredError: if the model's node type has no backend URL.
+    """
+    entry = next((m for m in registry.models if m.name == model), None)
+    if entry is None:
+        raise ModelNotFoundError(model)
+    node_type = entry.node_types[0]
+    url = registry.backends.get(node_type)
+    if url is None:
+        raise BackendNotConfiguredError(node_type)
+    return str(url).rstrip("/")

--- a/packages/orchestrator/src/orchestrator/settings.py
+++ b/packages/orchestrator/src/orchestrator/settings.py
@@ -1,5 +1,7 @@
 """Orchestrator configuration, sourced from environment variables."""
 
+from pathlib import Path
+
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -8,8 +10,8 @@ class Settings(BaseSettings):
 
     model_config = SettingsConfigDict(env_prefix="")
 
-    backend_url: str = "http://localhost:8080"
-    """Base URL of the inference backend to forward requests to."""
+    registry_path: Path = Path("configs/models.yaml")
+    """Path to the shared model registry (models.yaml). Overridable via REGISTRY_PATH."""
 
     backend_timeout_seconds: float = 120.0
     """Timeout for backend requests. Model inference is slow, so this is generous."""

--- a/packages/orchestrator/tests/conftest.py
+++ b/packages/orchestrator/tests/conftest.py
@@ -1,4 +1,7 @@
-"""Shared fixtures: an in-process orchestrator app pointed at a fake backend URL."""
+"""Shared fixtures: an in-process orchestrator app backed by a test registry."""
+
+import textwrap
+from pathlib import Path
 
 import httpx
 import pytest
@@ -6,12 +9,28 @@ from orchestrator.main import app
 from orchestrator.settings import settings
 
 FAKE_BACKEND_URL = "http://backend.test"
+TEST_MODEL = "Qwen/Qwen2.5-0.5B-Instruct-GGUF:Q4_K_M"
 
 
 @pytest.fixture
-def backend_url(monkeypatch: pytest.MonkeyPatch) -> str:
-    """Point the orchestrator at a fake backend URL that respx can intercept."""
-    monkeypatch.setattr(settings, "backend_url", FAKE_BACKEND_URL)
+def backend_url(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> str:
+    """Point the orchestrator at a test registry whose only model maps to a fake
+    backend URL that respx can intercept."""
+    registry_file = tmp_path / "models.yaml"
+    registry_file.write_text(
+        textwrap.dedent(f"""\
+        backends:
+          gpu: {FAKE_BACKEND_URL}
+        models:
+          - name: "{TEST_MODEL}"
+            quantization: Q4_K_M
+            size_b: 0.5
+            format: gguf
+            node_types: [gpu]
+            source_url: https://example.test/model.gguf
+        """)
+    )
+    monkeypatch.setattr(settings, "registry_path", registry_file)
     return FAKE_BACKEND_URL
 
 
@@ -19,8 +38,8 @@ def backend_url(monkeypatch: pytest.MonkeyPatch) -> str:
 async def client(backend_url: str):
     """An async client talking to the orchestrator app in-process via ASGI.
 
-    Runs the app's lifespan (startup/shutdown) so `app.state.http_client`
-    exists, exactly as it would under a real server.
+    Runs the app's lifespan (startup/shutdown) so `app.state.registry` and
+    `app.state.http_client` exist, exactly as they would under a real server.
     """
     async with app.router.lifespan_context(app):
         transport = httpx.ASGITransport(app=app)

--- a/packages/orchestrator/tests/test_completions.py
+++ b/packages/orchestrator/tests/test_completions.py
@@ -80,3 +80,14 @@ async def test_forwarded_payload_matches_the_request(
     assert forwarded_body["model"] == REQUEST_PAYLOAD["model"]
     assert forwarded_body["messages"] == REQUEST_PAYLOAD["messages"]
     assert forwarded_body["stream"] is False
+
+
+async def test_unknown_model_returns_404(client: httpx.AsyncClient, backend_url: str) -> None:
+    """A model absent from the registry yields a 404 with a helpful message."""
+    response = await client.post(
+        "/v1/chat/completions",
+        json={"model": "no-such-model", "messages": [{"role": "user", "content": "hi"}]},
+    )
+
+    assert response.status_code == 404
+    assert response.json() == {"error": "model 'no-such-model' not found in registry"}

--- a/packages/orchestrator/tests/test_resolution.py
+++ b/packages/orchestrator/tests/test_resolution.py
@@ -1,0 +1,41 @@
+"""Unit tests for the pure model-to-backend resolution function."""
+
+import pytest
+from common.registry import ModelRegistry
+from orchestrator.resolution import (
+    BackendNotConfiguredError,
+    ModelNotFoundError,
+    resolve_backend,
+)
+
+
+def _registry(**overrides) -> ModelRegistry:
+    data = {
+        "backends": {"gpu": "http://gpu.test", "edge": "http://edge.test"},
+        "models": [
+            {
+                "name": "m-gpu",
+                "quantization": "Q4_K_M",
+                "size_b": 1.0,
+                "format": "gguf",
+                "node_types": ["gpu", "edge"],
+                "source_url": "https://example.test/m.gguf",
+            }
+        ],
+    }
+    data.update(overrides)
+    return ModelRegistry.model_validate(data)
+
+
+def test_resolves_to_first_node_type() -> None:
+    assert resolve_backend(_registry(), "m-gpu") == "http://gpu.test"
+
+
+def test_unknown_model_raises() -> None:
+    with pytest.raises(ModelNotFoundError):
+        resolve_backend(_registry(), "missing")
+
+
+def test_missing_backend_raises() -> None:
+    with pytest.raises(BackendNotConfiguredError):
+        resolve_backend(_registry(backends={}), "m-gpu")


### PR DESCRIPTION
Wires the orchestrator to the shared model registry: it loads `configs/models.yaml`
at startup and resolves the backend URL from the requested model's node type,
replacing the hardcoded `backend_url`.

Stacked on #59 (mocked orchestrator tests) — GitHub will retarget the base to `main` once #59 merges.

Closes #11

## Changes
- `ModelRegistry` gains an optional `backends` map (node type → URL).
- `configs/models.yaml` gains a `backends:` section.
- New pure `resolve_backend(registry, model)` — uses the model's first node type.
- Lifespan loads the registry (fail-fast on missing/invalid YAML).
- Chat endpoint returns 404 for unknown models; forwarder takes the resolved URL.
- `settings`: drop `backend_url`, add `registry_path`.

## Acceptance criteria
- [x] Startup fails clearly on invalid/missing models.yaml
- [x] Registered models route to the correct backend
- [x] Unknown models return 404 with a helpful message
- [x] No hardcoded model/backend data in orchestrator source

## Verification
- `uv run pytest packages/ -v` → 23 passed (existing mocked tests + new: unknown-model 404, resolution unit tests, backends schema).
- End-to-end on an RTX 3050 (4 GB): `llama-server` on :8080 serving qwen3-1.7b; the orchestrator routed `model: qwen3-1.7b-q4` to it and returned a real completion; unknown model → 404 `{"error": "model 'x' not found in registry"}`; missing `REGISTRY_PATH` → startup fails with `FileNotFoundError` / "Application startup failed. Exiting."
- ruff check / format clean.